### PR TITLE
Add FilesystemDisplay cleanup

### DIFF
--- a/src/_renderer.js
+++ b/src/_renderer.js
@@ -495,6 +495,16 @@ async function initUI() {
         parentId: "filesystem"
     });
 
+    window.addEventListener("unload", () => {
+        if (window.fsDisp) window.fsDisp.destroy();
+    });
+
+    if (module && module.hot) {
+        module.hot.dispose(() => {
+            if (window.fsDisp) window.fsDisp.destroy();
+        });
+    }
+
     await _delay(200);
 
     document.getElementById("filesystem").setAttribute("style", "opacity: 1;");

--- a/src/classes/filesystem.class.js
+++ b/src/classes/filesystem.class.js
@@ -123,11 +123,26 @@ class FilesystemDisplay {
             if (this._fsWatcher) {
                 this._fsWatcher.close();
             }
-            this._fsWatcher = fs.watch(dir, (eventType, filename) => {
-                if (eventType != "change") { // #758 - Don't refresh file view if only file contents have changed.
-                    this._runNextTick = true;
-                }
-            });
+            try {
+                this._fsWatcher = fs.watch(dir, (eventType, filename) => {
+                    if (eventType != "change") { // #758 - Don't refresh file view if only file contents have changed.
+                        this._runNextTick = true;
+                    }
+                });
+                this._fsWatcher.on('error', () => {}); // Ignore watcher errors gracefully
+            } catch(e) {
+                console.warn('Failed to watch', dir, e);
+            }
+        };
+
+        this.destroy = () => {
+            clearInterval(this._timer);
+            if (this._fsWatcher) {
+                try {
+                    this._fsWatcher.close();
+                } catch(e) {}
+                this._fsWatcher = null;
+            }
         };
 
         this.toggleHidedotfiles = () => {


### PR DESCRIPTION
## Summary
- add destroy method to FilesystemDisplay
- gracefully handle fs.watch errors
- clean up the watcher and timer when the window unloads or a module is replaced

## Testing
- `npm test` *(fails: Cannot find module 'terser')*

------
https://chatgpt.com/codex/tasks/task_b_6855e1618fac8325a263c504a82ce187