### PR TITLE
Extend shell opacity setting to window

### DIFF
--- a/src/_boot.js
+++ b/src/_boot.js
@@ -190,7 +190,8 @@ function createWindow(settings) {
         fullscreen: settings.forceFullscreen || false,
         autoHideMenuBar: true,
         frame: settings.allowWindowed || false,
-        backgroundColor: '#000000',
+        transparent: true,
+        backgroundColor: '#00000000',
         webPreferences: {
             devTools: true,
 	    enableRemoteModule: true,
@@ -212,6 +213,7 @@ function createWindow(settings) {
 
     signale.complete("Frontend window created!");
     win.show();
+    win.setOpacity(settings.shellOpacity || 1);
     if (!settings.allowWindowed) {
         win.setResizable(false);
     } else if (!require(lastWindowStateFile)["useFullscreen"]) {

--- a/src/_renderer.js
+++ b/src/_renderer.js
@@ -379,6 +379,7 @@ async function initUI() {
     await _delay(10);
 
     document.getElementById("main_shell").setAttribute("style", "");
+    document.body.style.opacity = window.settings.shellOpacity || 1;
     document.getElementById("main_shell").style.opacity = window.settings.shellOpacity || 1;
 
     await _delay(270);
@@ -682,7 +683,7 @@ window.openSettings = async () => {
                     </tr>
                     <tr>
                         <td>shellOpacity</td>
-                        <td>Opacity of the main shell (0.0 - 1.0)</td>
+                        <td>Opacity of the entire interface (0.0 - 1.0)</td>
                         <td><input type="number" step="0.1" min="0" max="1" id="settingsEditor-shellOpacity" value="${window.settings.shellOpacity || '1.0'}"></td>
                     </tr>
                     <tr>


### PR DESCRIPTION
## Summary
- make Electron window transparent and apply shell opacity to entire interface
- update settings editor description

## Testing
- `npm test` *(fails: Cannot find module 'terser')*

------
https://chatgpt.com/codex/tasks/task_b_686a0a1392048325842785175b164fe9